### PR TITLE
Adding @koudaiii (Kodai) and @horihiro (Hirofumi) as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,42 @@
-@yuhattor
+# See GitHub documentation:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @yuhattor @koudaiii @horihiro
+
+# Trying out folder-specific CODEOWNERS permissions, by example of our Japanese book
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+# /build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+# /docs/ @doctocat


### PR DESCRIPTION
**Kodai Sakabe (@koudaiii)** played a big role in organizing the design of this action and getting it stable and publicly available.

**Hirofumi Horikawa (@horihiro)** has done a huge job in maintaining the development environment for this github action and ensuring that the activation/deactivation of revisions is carried out.

I would also like to thank **Ryosuke Hyakuta (@ry0y4n)**, who was not added to CODEOWNER at this time, but participated in the development as an intern. He took the lead in the early development and did extensive development including instructions and test environment.

Considering the widespread use of this Action in the future, and to ensure its ongoing management, I am adding both of them as CODEOWNERS :tada:

